### PR TITLE
Preserve all id2taxa mappings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,11 @@ scalaVersion := "2.11.8"
 
 bucketSuffix  := "era7.com"
 
+resolvers := Seq(
+  "Era7 private maven releases"  at s3("private.releases.era7.com").toHttps(s3region.value.toString),
+  "Era7 private maven snapshots" at s3("private.snapshots.era7.com").toHttps(s3region.value.toString)
+) ++ resolvers.value
+
 libraryDependencies ++= Seq(
   "ohnosequences" %% "fastarious" % "0.6.0",
   "ohnosequences" %% "blast-api"  % "0.7.0",

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -26,7 +26,7 @@ trait AnyBlastDB {
 
   val rnaCentralRelease: AnyRNACentral
   private[db] lazy val sourceFasta: S3Object = rnaCentralRelease.fasta
-  private[db] lazy val sourceTable: S3Object = rnaCentralRelease.tableActive
+  private[db] lazy val sourceTable: S3Object = rnaCentralRelease.table
 
   val s3location: S3Folder
 }

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -11,10 +11,9 @@ import ohnosequencesBundles.statika.Blast
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.transfer._
 
-import com.github.tototoshi.csv._
-
 import better.files._
 
+import com.github.tototoshi.csv._
 import csvUtils._, RNACentral5._
 
 
@@ -27,7 +26,7 @@ trait AnyBlastDB {
 
   val rnaCentralRelease: AnyRNACentral
   private[db] lazy val sourceFasta: S3Object = rnaCentralRelease.fasta
-  private[db] lazy val sourceTable: S3Object = rnaCentralRelease.id2taxaactive
+  private[db] lazy val sourceTable: S3Object = rnaCentralRelease.tableActive
 
   val s3location: S3Folder
 }

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -125,33 +125,36 @@ trait AnyGenerateBlastDB extends AnyBundle {
     val tableReader = CSVReader.open(tableInFile.toJava)(tableFormat)
     val tableWriter = CSVWriter.open(tableOutFile.toJava, append = true)(tableFormat)
 
-    val rows: Iterator[Row] = tableReader.iterator
-    val fastas: Iterator[FASTA.Value] = parseFastaDropErrors(fastaInFile.lines)
+    // Loading the whole FASTA map in memory:
+    val fastas: Map[String, FASTA.Value] = parseFastaDropErrors(fastaInFile.lines)
+      .map{ f => f.getV(header).id -> f }.toMap
 
-    // NOTE: here we rely on that the sources are prefiltered and don't have duplicate ID
-    (rows zip fastas)
-      .filter { case (row, fasta) => db.predicate(row, fasta) }
-      .foreach { case (row, fasta) =>
+    val groupedRows = tableReader.iterator.toStream.groupBy { _.select(id) }
 
-        val rowID = row.select(id)
-        val fastaID = fasta.getV(header).id
+    groupedRows.foreach { case (commonID, rows) =>
 
-        if (rowID != fastaID)
-          sys.error(s"Table row ID [${rowID}] doesn't match FASTA ID [${fastaID}]!")
+      // NOTE: this makes prefiltering of the RNACentral DB quite pointless
+      fastas.get(commonID) match {
+        case None => sys.error(s"ID [${commonID}] is not found in the FASTA. Check RNACentral filtering.")
+        case Some(fasta) => {
 
-        val extID = s"${rowID}|lcl|${db.name}"
+          val extID = s"${commonID}|lcl|${db.name}"
 
-        tableWriter.writeRow(List(
-          extID,
-          row.select(tax_id)
-        ))
+          val taxas: Set[String] = rows
+            .filter{ db.predicate(_, fasta) }
+            .map{ _.select(tax_id) }
+            .toSet
 
-        fastaOutFile.appendLine(
-          fasta.update(
-            header := FastaHeader(s"${extID} ${fasta.getV(header).description}")
-          ).asString
-        )
+          tableWriter.writeRow( Seq(extID, taxas.mkString(";")) )
+
+          fastaOutFile.appendLine(
+            fasta.update(
+              header := FastaHeader(s"${extID} ${fasta.getV(header).description}")
+            ).asString
+          )
+        }
       }
+    }
 
     tableReader.close()
     tableWriter.close()

--- a/src/main/scala/blastDB.scala
+++ b/src/main/scala/blastDB.scala
@@ -113,7 +113,7 @@ trait AnyGenerateBlastDB extends AnyBundle {
   }
 
   // This is the main processing part, that is separate to facilitate local testing
-  final def processSources(
+  def processSources(
     tableInFile: File,
     tableOutFile: File
   )(fastaInFile: File,
@@ -133,7 +133,6 @@ trait AnyGenerateBlastDB extends AnyBundle {
 
     groupedRows.foreach { case (commonID, rows) =>
 
-      // NOTE: this makes prefiltering of the RNACentral DB quite pointless
       fastas.get(commonID) match {
         case None => sys.error(s"ID [${commonID}] is not found in the FASTA. Check RNACentral filtering.")
         case Some(fasta) => {
@@ -162,8 +161,8 @@ trait AnyGenerateBlastDB extends AnyBundle {
 
 }
 
-class GenerateBlastDB[DB <: AnyBlastDB](val db: DB)
-  extends Bundle(blastBundle)
+class GenerateBlastDB[DB <: AnyBlastDB](val db: DB)(deps: AnyBundle*)
+  extends Bundle(blastBundle +: deps.toSeq: _*)
   with AnyGenerateBlastDB { type BlastDB = DB }
 
 

--- a/src/main/scala/csvUtils.scala
+++ b/src/main/scala/csvUtils.scala
@@ -13,16 +13,6 @@ case object csvUtils {
     override val escapeChar = '†'
   }
 
-  def csvReader(file: File): CSVReader = CSVReader.open(file.toJava)(tableFormat)
-
-  def lines(file: File): Iterator[Seq[String]] = csvReader(file) iterator
-
-  // TODO much unsafe, add errors
-  def rows(file: File)(headers: Seq[String]): Iterator[Map[String,String]] =
-    lines(file) map { line => (headers zip line) toMap }
-
-
-  // TODO: use a better representation for the table row
   type Row = Seq[String]
 
   implicit def rowOps(row: Row): RowOps = RowOps(row)

--- a/src/main/scala/rnaCentral.scala
+++ b/src/main/scala/rnaCentral.scala
@@ -3,9 +3,15 @@ package era7bio.db
 import ohnosequences.cosas._, types._, records._, klists._
 import ohnosequences.awstools._, regions.Region._, ec2._, InstanceType._, autoscaling._, s3._
 import ohnosequences.statika._, aws._
-import better.files._
+import ohnosequences.fastarious._, fasta._
+
 import com.amazonaws.auth._
 import com.amazonaws.services.s3.transfer._
+
+import better.files._
+
+import com.github.tototoshi.csv._
+import csvUtils._
 
 /*
   ## RNACentral data
@@ -16,13 +22,15 @@ abstract class AnyRNACentral(val version: String) {
 
   lazy val prefix = S3Object("resources.ohnosequences.com","")/"rnacentral"/version/
 
-  val fastaFileName           : String = s"rnacentral.${version}.fasta"
-  val id2taxaFileName         : String = s"id2taxa.${version}.tsv"
-  val id2taxaactiveFileName   : String = s"id2taxa.active.${version}.tsv"
+  val fastaFileName:       String = s"rnacentral.${version}.fasta"
+  val tableFileName:       String = s"table.${version}.tsv"
+  val tableActiveFileName: String = s"table.active.${version}.tsv"
+  val id2taxasFileName:    String = s"id2taxas.active.${version}.tsv"
 
-  lazy val fasta          : S3Object = prefix/fastaFileName
-  lazy val id2taxa        : S3Object = prefix/id2taxaFileName
-  lazy val id2taxaactive  : S3Object = prefix/id2taxaactiveFileName
+  lazy val fasta:       S3Object = prefix/fastaFileName
+  lazy val table:       S3Object = prefix/tableFileName
+  lazy val tableActive: S3Object = prefix/tableActiveFileName
+  lazy val id2taxas:    S3Object = prefix/id2taxasFileName
 }
 
 case object RNACentral5 extends AnyRNACentral("5.0") {
@@ -58,8 +66,9 @@ case object RNACentral5 extends AnyRNACentral("5.0") {
   This bundle
 
   1. downloads all RNACentral raw files from the EBI ftp
-  2. creates other id2taxa file containing only the *active* sequences (those actually found in RNACentral)
-  3. uploads everything to S3
+  2. creates other table file containing only the *active* sequences (those actually found in RNACentral)
+  3. creates a 2-column table with id to taxas mapping (only active ids)
+  4. uploads everything to S3
 */
 class MirrorRNAcentral[R <: AnyRNACentral](r: R) extends Bundle() {
 
@@ -68,115 +77,94 @@ class MirrorRNAcentral[R <: AnyRNACentral](r: R) extends Bundle() {
 
   lazy val dataFolder = file"/media/ephemeral0"
 
-  lazy val rnaCentralFastaFile    = dataFolder/"rnacentral_active.fasta"
-  lazy val rnaCentralFastaFileGz  = dataFolder/"rnacentral_active.fasta.gz"
-  lazy val id2taxaFileGz          = dataFolder/"id_mapping.tsv.gz"
-  lazy val id2taxaFile            = dataFolder/"id_mapping.tsv"
-  lazy val id2taxaactiveFile      = dataFolder/rnaCentral.id2taxaactiveFileName
-  lazy val errLogFile             = dataFolder/s"${toString}.log"
+  // inputs:
+  lazy val rnaCentralFastaFile = dataFolder/"rnacentral_active.fasta"
+  lazy val tableFile           = dataFolder/"id_mapping.tsv"
+  // outputs:
+  lazy val tableActiveFile = dataFolder/rnaCentral.tableActiveFileName
+  lazy val id2taxasFile    = dataFolder/rnaCentral.id2taxasFileName
 
   lazy val getRnaCentralFastaFileGz = cmd("wget")(
-    s"ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/releases/${rnaCentral.version}/sequences/rnacentral_active.fasta.gz"
+    s"ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/releases/${rnaCentral.version}/sequences/${rnaCentralFastaFile.name}.gz"
   )
-  lazy val extractRnaCentralFastaFile = cmd("gzip")("-d", rnaCentralFastaFileGz.name)
-
   lazy val getRnaCentralIdMappingGz = cmd("wget")(
-    s"ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/releases/${rnaCentral.version}/id_mapping/id_mapping.tsv.gz"
+    s"ftp://ftp.ebi.ac.uk/pub/databases/RNAcentral/releases/${rnaCentral.version}/id_mapping/${tableFile.name}.gz"
   )
-  lazy val extractRnaCentralIdMapping = cmd("gzip")("-d", id2taxaFileGz.name)
 
-  def instructions: AnyInstructions =
+  def instructions: AnyInstructions = {
     // get raw input stuff from EBI FTP
-    getRnaCentralFastaFileGz -&- extractRnaCentralFastaFile -&-
-    getRnaCentralIdMappingGz -&- extractRnaCentralIdMapping -&-
-    LazyTry[String] {
-    // drop inactive ids from the id2taxa file
-    fileWrangling.filterInactiveIds(
-      rnaCentralFastaFile = rnaCentralFastaFile,
-      id2taxaFile         = id2taxaFile,
-      id2taxaactiveFile   = id2taxaactiveFile,
-      errLogFile          = errLogFile
-    )
+    getRnaCentralFastaFileGz -&-
+    cmd("gzip")("-d", s"${rnaCentralFastaFile.name}.gz") -&-
+    getRnaCentralIdMappingGz -&-
+    cmd("gzip")("-d", s"${tableFile.name}.gz") -&-
+    LazyTry {
 
-    val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+      val fastaIDs: Set[String] = fasta
+        .parseFastaDropErrors(rnaCentralFastaFile.lines)
+        .map{ _.getV(header).id }
+        .toSet
 
-    // upload the uncompressed fasta file
-    transferManager.upload(
-      rnaCentral.fasta.bucket, rnaCentral.fasta.key,
-      rnaCentralFastaFile.toJava
-    )
-    .waitForCompletion
+      val tableReader = CSVReader.open(tableFile.toJava)(tableFormat)
 
-    // upload full id2taxa file
-    transferManager.upload(
-      rnaCentral.id2taxa.bucket, rnaCentral.id2taxa.key,
-      id2taxaFile.toJava
-    )
-    .waitForCompletion
+      val tableActiveWriter = CSVWriter.open(tableActiveFile.toJava, append = true)(tableFormat)
+      val id2taxasWriter    = CSVWriter.open(id2taxasFile.toJava,    append = true)(tableFormat)
 
-    // upload active id2taxa file
-    transferManager.upload(
-      rnaCentral.id2taxaactive.bucket, rnaCentral.id2taxaactive.key,
-      id2taxaactiveFile.toJava
-    )
-    .waitForCompletion
+      // TODO: check that all fastaIDs are present in the table?
+      // errLogFile << s"${fa.getV(header)} not found in ${id2taxaFile}. All subsequent will fail"
 
-    s"RNACentral version ${rnaCentral.version} mirrored at ${rnaCentral.prefix} including active-only id2taxa mapping"
-  }
-}
+      import RNACentral5._
 
-case object fileWrangling {
+      tableReader.iterator.toStream
+        .groupBy { _.select(id) }
+        .foreach { case (id, rows) =>
+          if (fastaIDs.contains(id)) {
 
-  import RNACentral5._
+            // writing all rows for this ID to the active table
+            rows.foreach { tableActiveWriter.writeRow }
 
-  /*
-    ### Filter inactive ids from the id2taxa file
+            // writing ID with all taxIDs corresponding to it (in one column)
+            val taxas = rows.map{ _.select(tax_id) }.distinct.mkString("; ")
+            id2taxasWriter.writeRow(Seq(id, taxas))
 
-    This method keeps from the id2taxa csv those present in the active RNACentral fasta. It will fail if at least **one** fasta id is not found in the id2taxa csv.
+          } else {
 
-    > **WARNING** This implementation reuses iterators, something about which the Scala std docs say: "Using the old iterator is undefined, subject to change, and may result in changes to the new iterator as well."
-    >
-    > I tried to do it in a different way but I couldn't. `iterator.span` is crap, as other iterator methods:
-    >
-    > - http://grokbase.com/t/gg/scala-user/12bknnwmbg/why-does-this-iterator-cause-a-stack-overflow#20121119kgsf2s3oryv5xbp2z62sa7cg4e
-    > - https://issues.scala-lang.org/browse/SI-9332
-    > - https://issues.scala-lang.org/browse/SI-5838
-    > - https://groups.google.com/forum/#!topic/scala-user/s3UutoCEckg
-  */
-  def filterInactiveIds(
-    rnaCentralFastaFile : File,
-    id2taxaFile         : File,
-    id2taxaactiveFile   : File,
-    errLogFile          : File
-  )
-  : Unit = {
-
-    import ohnosequences.fastarious._, fasta._
-
-    // here we drop any errors from the taxid mapping file
-    val allIds = csvUtils.rows(id2taxaFile)(Id2Taxa.keys.types map typeLabel asList)
-      .map(Id2Taxa.parse(_))
-      .collect({ case Right(rec) => rec })
-
-    fasta.parseFastaDropErrors(rnaCentralFastaFile.lines).foreach(
-
-      fa => {
-
-        val faId = fa.getV(header).id
-        // advance ids, get current
-        val rest   = allIds.dropWhile( _.getV(id) != faId )
-
-        if(allIds.hasNext) {
-          // we are just getting the first assignment here
-          val rec = rest.next
-          id2taxaactiveFile << s"${rec.getV(id)}\t${rec.getV(db)}\t${rec.getV(external_id)}\t${rec.getV(tax_id)}\t${rec.getV(rna_type)}\t${rec.getV(gene_name)}"
+            // TODO: write these inactive ids somewhere?
+            println(s"Skipping inactive ID: ${id}")
+          }
         }
-        else {
 
-          errLogFile << s"${fa.getV(header)} not found in ${id2taxaFile}. All subsequent will fail"
-        }
-      }
-    )
+      tableReader.close()
+      tableActiveWriter.close()
+      id2taxasWriter.close()
+    } -&-
+    LazyTry {
+      val transferManager = new TransferManager(new InstanceProfileCredentialsProvider())
+
+      // upload the uncompressed fasta file
+      transferManager.upload(
+        rnaCentral.fasta.bucket, rnaCentral.fasta.key,
+        rnaCentralFastaFile.toJava
+      ).waitForCompletion
+
+      // upload full table file
+      transferManager.upload(
+        rnaCentral.table.bucket, rnaCentral.table.key,
+        tableFile.toJava
+      ).waitForCompletion
+
+      // upload active table file
+      transferManager.upload(
+        rnaCentral.tableActive.bucket, rnaCentral.tableActive.key,
+        tableActiveFile.toJava
+      ).waitForCompletion
+
+      // upload id2taxas file
+      transferManager.upload(
+        rnaCentral.id2taxas.bucket, rnaCentral.id2taxas.key,
+        id2taxasFile.toJava
+      ).waitForCompletion
+    } -&-
+    say(s"RNACentral version ${rnaCentral.version} mirrored at ${rnaCentral.prefix} including active-only table mapping")
   }
 }
 

--- a/src/test/scala/runBundles.scala
+++ b/src/test/scala/runBundles.scala
@@ -15,7 +15,7 @@ case object runBundles {
       .runInstances(
         amount = 1,
         compat.instanceSpecs(
-          c3.x2large,
+          r3.x2large,
           user.keypair.name,
           Some(ec2Roles.projects.name)
         )


### PR DESCRIPTION
Instead of picking the first one, it should write all of them in the `id2taxa.csv`. Columns:
- id
- all taxas separated with `; `
