### PR TITLE
Follow naming/S3-locations conventions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 Nice.scalaProject
 
-name          := "rnacentraldb"
+name          := "db.rnacentral"
 organization  := "era7bio"
 description   := "Code generation and bundle for a 18S RNA databases"
 
@@ -34,8 +34,8 @@ parallelExecution in Test := false
 fatArtifactSettings
 
 enablePlugins(BuildInfoPlugin)
-buildInfoPackage := "generated.metadata"
-buildInfoObject  := name.value
+buildInfoPackage := "generated.metadata.db"
+buildInfoObject  := "rnacentral"
 buildInfoOptions := Seq(BuildInfoOption.Traits("ohnosequences.statika.AnyArtifactMetadata"))
 buildInfoKeys    := Seq[BuildInfoKey](
   organization,

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,12 @@
 ### RNA reference databases
 
-[![](https://travis-ci.org/era7bio/18s-its-database.svg?branch=master)](https://travis-ci.org/era7bio/18s-its-database)
-[![](https://img.shields.io/codacy/???.svg)](https://www.codacy.com/app/era7bio/18s-its-database)
-[![](https://img.shields.io/github/release/era7bio/18s-its-database.svg)](https://github.com/era7bio/18s-its-database/releases/latest)
+[![](https://travis-ci.org/era7bio/db.rnacentral.svg?branch=master)](https://travis-ci.org/era7bio/db.rnacentral)
+[![](https://img.shields.io/codacy/???.svg)](https://www.codacy.com/app/era7bio/db.rnacentral)
+[![](http://github-release-version.herokuapp.com/github/era7bio/db.rnacentral/release.svg)](https://github.com/era7bio/db.rnacentral/releases/latest)
 [![](https://img.shields.io/badge/license-AGPLv3-blue.svg)](https://tldrlegal.com/license/gnu-affero-general-public-license-v3-%28agpl-3.0%29)
-[![](https://img.shields.io/badge/contact-gitter_chat-dd1054.svg)](https://gitter.im/era7bio/18s-its-database)
+[![](https://img.shields.io/badge/contact-gitter_chat-dd1054.svg)](https://gitter.im/era7bio/db.rnacentral)
 
-Reference databases for RNA data. Includes
+This is a bundle for mirroring [RNAcentral](http://rnacentral.org/) database in S3 and the common code for building BLAST reference databases:
 
-0. filtering of only present IDs from the id to taxa mappings, dropping external IDs fields
-1. a BLAST database from source FASTA containing all sequences from RNACentral
-<!-- 2. statika bundles for both making new database releases and using them -->
-
-The source data for *all* the BLAST databases here comes from [RNAcentral](http://rnacentral.org/).
+- [era7bio/db.rna16s](https://github.com/era7bio/db.rna16s)
+- [era7bio/db.rna18s](https://github.com/era7bio/db.rna18s)

--- a/src/main/scala/rnaCentral.scala
+++ b/src/main/scala/rnaCentral.scala
@@ -20,7 +20,12 @@ import csvUtils._
 */
 abstract class AnyRNACentral(val version: String) {
 
-  lazy val prefix = S3Object("resources.ohnosequences.com","")/"rnacentral"/version/
+  val metadata = generated.metadata.db.rnacentral
+
+  lazy val prefix = S3Object("resources.ohnosequences.com", metadata.organization)
+    metadata.artifact /
+    version / // of RNAcentral
+    metadata.version.stripSuffix("-SNAPSHOT")
 
   val fastaFileName:       String = s"rnacentral.${version}.fasta"
   val tableFileName:       String = s"table.${version}.tsv"

--- a/src/test/scala/compats.scala
+++ b/src/test/scala/compats.scala
@@ -11,7 +11,7 @@ case object rnaCentralCompats {
       javaHeap = 20 // in G
     ),
     b,
-    generated.metadata.rnacentraldb
+    generated.metadata.db.rnacentral
   )
 
   // compatible:


### PR DESCRIPTION
sbt artifact & code: 
- org/name correspond to the github repo
- org becomes the base package for the scala code
- if the name has dots its prefix is appended to the scala package name

S3-location:
- `s3://resources.ohnosequences.com/<org>/<name>/<RNAcental_version>/<artifact_version>/`